### PR TITLE
Leave AST with errors unformatted

### DIFF
--- a/src/html/Ast.zig
+++ b/src/html/Ast.zig
@@ -546,7 +546,11 @@ const Formatter = struct {
         _ = fmt;
         _ = options;
 
-        try f.ast.render(f.src, out_stream);
+        if (f.ast.errors.len != 0) {
+            _ = try out_stream.write(f.src);
+        } else {
+            try f.ast.render(f.src, out_stream);
+        }
     }
 };
 


### PR DESCRIPTION
Trying to format an AST with errors resulted in an assertion failure. This fix makes it so that it returns the unchanged source.

With this, some failing unit tests on `src/html/Ast.zig` work as intended.