### PR TITLE
Make the match for "DOCTYPE" case-insensitive

### DIFF
--- a/src/html/Tokenizer.zig
+++ b/src/html/Tokenizer.zig
@@ -638,7 +638,7 @@ fn next2(self: *Tokenizer, src: []const u8) ?struct {
                     self.state = .{
                         .comment_start = self.idx,
                     };
-                } else if (self.nextCharsAre(DOCTYPE, src)) {
+                } else if (self.nextCharsAreIgnoreCase(DOCTYPE, src)) {
                     self.idx += @intCast(DOCTYPE.len);
                     self.state = .{ .doctype = lbracket };
                 } else if (self.nextCharsAre("[CDATA[", src)) {
@@ -885,6 +885,10 @@ fn next2(self: *Tokenizer, src: []const u8) ?struct {
 
 fn nextCharsAre(self: Tokenizer, needle: []const u8, src: []const u8) bool {
     return std.mem.startsWith(u8, src[self.idx..], needle);
+}
+
+fn nextCharsAreIgnoreCase(self: Tokenizer, needle: []const u8, src: []const u8) bool {
+    return std.ascii.startsWithIgnoreCase(src[self.idx..], needle);
 }
 
 fn isAsciiAlphaLower(c: u8) bool {


### PR DESCRIPTION
Under section 13.2.5.42 of the HTML specification, it is stated that it should be:
> ASCII case-insensitive match for the word "DOCTYPE"

This is not the case with "--" nor "[CDATA[", under the same section, so those don't need to be updated.