### PR TITLE
Add missing obsolete elements to the list

### DIFF
--- a/src/html/Ast.zig
+++ b/src/html/Ast.zig
@@ -25,8 +25,31 @@ const rawtext_names = TagNameMap.initComptime(.{
 });
 
 const unsupported_names = TagNameMap.initComptime(.{
-    .{ "plaintext", {} },
+    .{ "applet", {} },
+    .{ "acronym", {} },
+    .{ "bgsound", {} },
+    .{ "dir", {} },
+    .{ "frame", {} },
+    .{ "frameset", {} },
+    .{ "noframes", {} },
+    .{ "hgroup", {} },
+    .{ "isindex", {} },
     .{ "listing", {} },
+    .{ "nextid", {} },
+    .{ "noembed", {} },
+    .{ "plaintext", {} },
+    .{ "strike", {} },
+    .{ "xmp", {} },
+    .{ "basefont", {} },
+    .{ "big", {} },
+    .{ "blink", {} },
+    .{ "center", {} },
+    .{ "font", {} },
+    .{ "marquee", {} },
+    .{ "multicol", {} },
+    .{ "nobr", {} },
+    .{ "spacer", {} },
+    .{ "tt", {} },
 });
 
 const Node = struct {


### PR DESCRIPTION
With this addition there shouldn't be any missing obsolete elements.

See: https://www.w3.org/TR/2014/REC-html5-20141028/obsolete.html#non-conforming-features